### PR TITLE
Use full width for solo buttons

### DIFF
--- a/login-workflow/src/components/password/ChangePasswordModal.tsx
+++ b/login-workflow/src/components/password/ChangePasswordModal.tsx
@@ -19,6 +19,7 @@ import { FinishState } from '../FinishState';
 import CheckCircle from '@material-ui/icons/CheckCircle';
 import { defaultPasswordRequirements } from '../../constants';
 import { useDialogStyles } from '../../styles';
+import clsx from 'clsx';
 
 /**
  * Component that renders a change password form in a modal dialog. This dialog is automatically
@@ -41,6 +42,8 @@ export const ChangePasswordModal: React.FC = () => {
     const [currentPassword, setCurrentPassword] = useState('');
     const [password, setPassword] = useState('');
     const [confirm, setConfirm] = useState('');
+
+    const success = transitState.transitSuccess;
 
     const updateFields = useCallback(
         (fields: { password: string; confirm: string }) => {
@@ -72,7 +75,7 @@ export const ChangePasswordModal: React.FC = () => {
 
     // Dynamically change the body content based on successful change
     let body: JSX.Element;
-    if (transitState.transitSuccess) {
+    if (success) {
         body = (
             <FinishState
                 icon={<CheckCircle color={'primary'} style={{ fontSize: 100, marginBottom: theme.spacing(2) }} />}
@@ -121,26 +124,27 @@ export const ChangePasswordModal: React.FC = () => {
             <Divider style={{ marginTop: theme.spacing(2) }} />
             <DialogActions className={sharedClasses.dialogActions}>
                 <Grid container direction="row" alignItems="center" justify="space-between" style={{ width: '100%' }}>
-                    <Button
-                        variant="outlined"
-                        color="primary"
-                        className={sharedClasses.dialogButton}
-                        disabled={transitState.transitSuccess}
-                        onClick={(): void => securityHelper.hideChangePassword()}
-                    >
-                        {t('ACTIONS.BACK')}
-                    </Button>
+                    {!success && (
+                        <Button
+                            variant="outlined"
+                            color="primary"
+                            className={sharedClasses.dialogButton}
+                            onClick={(): void => securityHelper.hideChangePassword()}
+                        >
+                            {t('ACTIONS.BACK')}
+                        </Button>
+                    )}
                     <Button
                         variant="contained"
                         disableElevation
-                        className={sharedClasses.dialogButton}
+                        className={clsx(sharedClasses.dialogButton, { [sharedClasses.fullWidth]: success })}
                         disabled={
                             transitState.transitInProgress ||
-                            (!transitState.transitSuccess && (currentPassword === '' || !areValidMatchingPasswords()))
+                            (!success && (currentPassword === '' || !areValidMatchingPasswords()))
                         }
                         color="primary"
                         onClick={
-                            transitState.transitSuccess
+                            success
                                 ? (): void => {
                                       accountUIActions.dispatch(AccountActions.logout());
                                       securityHelper.onUserNotAuthenticated();
@@ -148,7 +152,7 @@ export const ChangePasswordModal: React.FC = () => {
                                 : changePassword
                         }
                     >
-                        {transitState.transitSuccess ? t('ACTIONS.LOG_IN') : t('ACTIONS.OKAY')}
+                        {success ? t('ACTIONS.LOG_IN') : t('ACTIONS.OKAY')}
                     </Button>
                 </Grid>
             </DialogActions>

--- a/login-workflow/src/screens/ContactSupport.tsx
+++ b/login-workflow/src/screens/ContactSupport.tsx
@@ -5,6 +5,7 @@ import {
     CardContent,
     Button,
     CardActions,
+    Divider,
     useTheme,
     Typography,
     makeStyles,
@@ -94,6 +95,7 @@ export const ContactSupport: React.FC = () => {
             <CardContent className={classes.dialogContent}>
                 <ContactSupportContent />
             </CardContent>
+            <Divider />
             <CardActions className={classes.dialogActions}>
                 <Button
                     variant="contained"

--- a/login-workflow/src/screens/ContactSupport.tsx
+++ b/login-workflow/src/screens/ContactSupport.tsx
@@ -15,6 +15,7 @@ import {
 import { BrandedCardContainer } from '../components';
 import ChatBubbleOutline from '@material-ui/icons/ChatBubbleOutline';
 import { useDialogStyles } from '../styles';
+import clsx from 'clsx';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -98,7 +99,7 @@ export const ContactSupport: React.FC = () => {
                     variant="contained"
                     color="primary"
                     disableElevation
-                    className={classes.dialogButton}
+                    className={clsx(classes.dialogButton, { [classes.fullWidth]: true })}
                     onClick={(): void => history.goBack()}
                 >
                     {t('ACTIONS.OKAY')}

--- a/login-workflow/src/screens/ForgotPassword.tsx
+++ b/login-workflow/src/screens/ForgotPassword.tsx
@@ -26,6 +26,7 @@ import {
 } from '@material-ui/core';
 import CheckCircle from '@material-ui/icons/CheckCircle';
 import { useDialogStyles } from '../styles';
+import clsx from 'clsx';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -66,6 +67,7 @@ export const ForgotPassword: React.FC = () => {
     const isInTransit = forgotPasswordTransit.transitInProgress;
     const hasTransitError = forgotPasswordTransit.transitErrorMessage !== null;
     const transitErrorMessage = forgotPasswordTransit.transitErrorMessage;
+    const finished = accountUIState.forgotPassword.transitSuccess;
 
     const resetPassword = useCallback(
         (email: string): void => {
@@ -166,22 +168,23 @@ export const ForgotPassword: React.FC = () => {
             <Divider />
             <CardActions className={sharedClasses.dialogActions}>
                 <Grid container direction="row" alignItems="center" justify="space-between" style={{ width: '100%' }}>
-                    <Button
-                        variant="outlined"
-                        color="primary"
-                        disabled={accountUIState.forgotPassword.transitSuccess}
-                        onClick={(): void => history.goBack()}
-                        className={sharedClasses.dialogButton}
-                    >
-                        {t('ACTIONS.BACK')}
-                    </Button>
+                    {!finished && (
+                        <Button
+                            variant="outlined"
+                            color="primary"
+                            onClick={(): void => history.goBack()}
+                            className={sharedClasses.dialogButton}
+                        >
+                            {t('ACTIONS.BACK')}
+                        </Button>
+                    )}
                     <Button
                         variant="contained"
                         disableElevation
                         disabled={!canContinue()}
                         color="primary"
                         onClick={onContinue}
-                        className={sharedClasses.dialogButton}
+                        className={clsx(sharedClasses.dialogButton, { [sharedClasses.fullWidth]: finished })}
                     >
                         {accountUIState.forgotPassword.transitSuccess ? t('ACTIONS.DONE') : t('ACTIONS.OKAY')}
                     </Button>

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -30,6 +30,7 @@ import { RegistrationComplete } from './subScreens/RegistrationComplete';
 import { ExistingAccountComplete } from './subScreens/ExistingAccountComplete';
 import Error from '@material-ui/icons/Error';
 import { useDialogStyles } from '../styles';
+import clsx from 'clsx';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 enum Pages {
@@ -293,7 +294,7 @@ export const InviteRegistrationPager: React.FC = () => {
                 variant={'contained'}
                 disableElevation
                 color={'primary'}
-                className={sharedClasses.dialogButton}
+                className={clsx(sharedClasses.dialogButton, { [sharedClasses.fullWidth]: true })}
                 onClick={(): void => advancePage(1)}
             >
                 {t('ACTIONS.CONTINUE')}

--- a/login-workflow/src/screens/ResetPassword.tsx
+++ b/login-workflow/src/screens/ResetPassword.tsx
@@ -15,6 +15,7 @@ import { defaultPasswordRequirements } from '../constants';
 import CheckCircle from '@material-ui/icons/CheckCircle';
 import Error from '@material-ui/icons/Error';
 import { useDialogStyles } from '../styles';
+import clsx from 'clsx';
 
 /**
  * Renders a screen stack which handles the reset password flow (deep link from email).
@@ -180,15 +181,16 @@ export const ResetPassword: React.FC = () => {
             <Divider />
             <CardActions className={classes.dialogActions}>
                 <Grid container direction="row" alignItems="center" justify="space-between" style={{ width: '100%' }}>
-                    <Button
-                        variant="outlined"
-                        color="primary"
-                        disabled={setPasswordTransitSuccess}
-                        onClick={(): void => history.push(routes.LOGIN)}
-                        className={classes.dialogButton}
-                    >
-                        {t('ACTIONS.BACK')}
-                    </Button>
+                    {!setPasswordTransitSuccess && (
+                        <Button
+                            variant="outlined"
+                            color="primary"
+                            onClick={(): void => history.push(routes.LOGIN)}
+                            className={classes.dialogButton}
+                        >
+                            {t('ACTIONS.BACK')}
+                        </Button>
+                    )}
                     {verifySuccess && (
                         <Button
                             variant="contained"
@@ -196,7 +198,7 @@ export const ResetPassword: React.FC = () => {
                             disabled={!canContinue()}
                             color="primary"
                             onClick={onContinue}
-                            className={classes.dialogButton}
+                            className={clsx(classes.dialogButton, { [classes.fullWidth]: setPasswordTransitSuccess })}
                         >
                             {setPasswordTransitSuccess ? t('ACTIONS.DONE') : t('ACTIONS.OKAY')}
                         </Button>

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -21,6 +21,7 @@ import { AccountDetails as AccountDetailsScreen } from './subScreens/AccountDeta
 import { RegistrationComplete } from './subScreens/RegistrationComplete';
 import { ExistingAccountComplete } from './subScreens/ExistingAccountComplete';
 import { useDialogStyles } from '../styles';
+import clsx from 'clsx';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 enum Pages {
@@ -394,7 +395,7 @@ export const SelfRegistrationPager: React.FC = () => {
             <Button
                 variant={'contained'}
                 color={'primary'}
-                className={sharedClasses.dialogButton}
+                className={clsx(sharedClasses.dialogButton, { [sharedClasses.fullWidth]: true })}
                 disableElevation
                 onClick={(): void => history.push(routes.LOGIN)}
             >
@@ -407,7 +408,7 @@ export const SelfRegistrationPager: React.FC = () => {
                 variant={'contained'}
                 color={'primary'}
                 disableElevation
-                className={sharedClasses.dialogButton}
+                className={clsx(sharedClasses.dialogButton, { [sharedClasses.fullWidth]: true })}
                 onClick={(): void => advancePage(1)}
             >
                 {t('ACTIONS.CONTINUE')}

--- a/login-workflow/src/styles/index.tsx
+++ b/login-workflow/src/styles/index.tsx
@@ -27,6 +27,9 @@ export const useDialogStyles = makeStyles((theme: Theme) =>
         },
         dialogButton: {
             width: 100,
+            '&$fullWidth': {
+                width: '100%',
+            },
         },
         fullDivider: {
             margin: `${theme.spacing(5)}px -${theme.spacing(3)}px ${theme.spacing(4)}px`,
@@ -48,5 +51,6 @@ export const useDialogStyles = makeStyles((theme: Theme) =>
                 marginTop: theme.spacing(3),
             },
         },
+        fullWidth: {},
     })
 );


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #12.

I did this using a new class and conditional application using clsx rather than conditionally turning off the class that is setting the fixed width. This way, we won't have to go in and add that all back in if we want to update some styles (other than width) for all of the dialog buttons at once.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Use full width buttons for finish screens (change password, reset password, registrations, support)

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/29152776/102228898-3987b900-3eb9-11eb-9661-56e61d15b293.png)
