### PR TITLE
Use product image from props for login

### DIFF
--- a/login-workflow/example/src/App.tsx
+++ b/login-workflow/example/src/App.tsx
@@ -10,6 +10,7 @@ import { ProjectAuthUIActions } from './actions/AuthUIActions';
 import { ProjectRegistrationUIActions } from './actions/RegistrationUIActions';
 import { ExampleHome } from './screens/ExampleHome';
 import { routes } from './navigation/Routing';
+import productLogo from './assets/images/eaton_stacked_logo.png';
 
 export const AuthUIConfiguration: React.FC = (props) => {
     const securityContextActions = useSecurityActions();
@@ -23,7 +24,7 @@ export const AuthUIConfiguration: React.FC = (props) => {
             htmlEula={false}
             contactEmail={'something@email.com'}
             contactPhone={'1-800-123-4567'}
-            projectImage={require('./assets/images/eaton_stacked_logo.png')}
+            projectImage={productLogo}
         >
             {props.children}
         </AuthUIContextProvider>

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -226,7 +226,11 @@ export const Login: React.FC = () => {
             >
                 <div className={classes.formContent}>
                     <div style={{ marginBottom: theme.spacing(6) }}>
-                        <img className={classes.productLogo} src={stackedEatonLogo} alt="logo" />
+                        <img
+                            className={classes.productLogo}
+                            src={authProps.projectImage || stackedEatonLogo}
+                            alt="logo"
+                        />
                     </div>
 
                     {debugMessage}


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #14.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Use the product logo from context instead of hardcoded image on login screen
- Update the image import syntax in the demo

Visually this will look identical, since we are using the eaton stacked logo as the default, but you can change the image in App.tsx if you want to try a different one.
