### PR TITLE
Enter Key transitions

### DIFF
--- a/login-workflow/src/components/password/ChangePasswordForm.tsx
+++ b/login-workflow/src/components/password/ChangePasswordForm.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState, useCallback } from 'react';
+import React, { ChangeEvent, useState, useCallback, MutableRefObject } from 'react';
 import { useLanguageLocale } from '@pxblue/react-auth-shared';
 import { Typography, Divider, useTheme } from '@material-ui/core';
 import { SecureTextField } from '../SecureTextField';
@@ -10,6 +10,9 @@ export type ChangePasswordFormProps = {
     passwordLabel?: string;
     confirmLabel?: string;
     description?: string;
+    passwordRef?: MutableRefObject<any>;
+    confirmRef?: MutableRefObject<any>;
+    onSubmit?: () => void;
 };
 
 /**
@@ -20,11 +23,23 @@ export type ChangePasswordFormProps = {
  * @param passwordLabel Optional label for the new password field (default = 'Password')
  * @param confirmLabel Optional label for the confirm password field (default = 'Confirm')
  * @param description Optional text to replace the instructional text above the password fields.
+ * @param passwordRef Optional ref to forward to the password input.
+ * @param confirmRef Optional ref to forward to the confirm password input.
+ * @param onSubmit Optional callback function to call when the mini form is submitted.
  *
  * @category Component
  */
 export const ChangePasswordForm: React.FC<ChangePasswordFormProps> = (props) => {
-    const { onPasswordChange, passwordLabel, confirmLabel, description, children } = props;
+    const {
+        onPasswordChange,
+        passwordLabel,
+        confirmLabel,
+        description,
+        children,
+        passwordRef,
+        confirmRef,
+        onSubmit,
+    } = props;
     const { t } = useLanguageLocale();
     const theme = useTheme();
     const sharedClasses = useDialogStyles();
@@ -59,19 +74,29 @@ export const ChangePasswordForm: React.FC<ChangePasswordFormProps> = (props) => 
             <SecureTextField
                 id="password"
                 name="password"
+                inputRef={passwordRef}
                 label={passwordLabel || t('FORMS.PASSWORD')}
                 value={passwordInput}
                 onChange={(evt: ChangeEvent<HTMLInputElement>): void => onPassChange(evt.target.value)}
                 className={sharedClasses.textField}
+                onKeyPress={(e): void => {
+                    if (e.key === 'Enter' && confirmRef.current) {
+                        confirmRef.current.focus();
+                    }
+                }}
             />
             <PasswordRequirements style={{ marginTop: theme.spacing(2) }} passwordText={passwordInput} />
             <SecureTextField
                 id="confirm"
                 name="confirm"
+                inputRef={confirmRef}
                 label={confirmLabel || t('FORMS.CONFIRM_PASSWORD')}
                 className={sharedClasses.textField}
                 value={confirmInput}
                 onChange={(evt: ChangeEvent<HTMLInputElement>): void => onConfirmChange(evt.target.value)}
+                onKeyPress={(e): void => {
+                    if (e.key === 'Enter' && onSubmit) onSubmit();
+                }}
             />
         </>
     );

--- a/login-workflow/src/components/password/ChangePasswordModal.tsx
+++ b/login-workflow/src/components/password/ChangePasswordModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, ChangeEvent } from 'react';
+import React, { useState, useCallback, ChangeEvent, useRef } from 'react';
 import {
     useSecurityState,
     useSecurityActions,
@@ -34,6 +34,9 @@ export const ChangePasswordModal: React.FC = () => {
     const securityHelper = useSecurityActions();
     const theme = useTheme();
     const sharedClasses = useDialogStyles();
+
+    const passwordRef = useRef(null);
+    const confirmRef = useRef(null);
 
     const [transitState, setTransitState] = useState(initialTransitState);
     const [hasAcknowledgedError, setHasAcknowledgedError] = useState(false);
@@ -82,12 +85,30 @@ export const ChangePasswordModal: React.FC = () => {
         );
     } else {
         body = (
-            <ChangePasswordForm passwordLabel={t('LABELS.NEW_PASSWORD')} onPasswordChange={updateFields}>
+            <ChangePasswordForm
+                passwordLabel={t('LABELS.NEW_PASSWORD')}
+                onPasswordChange={updateFields}
+                passwordRef={passwordRef}
+                confirmRef={confirmRef}
+                onSubmit={(): void => {
+                    if (
+                        transitState.transitInProgress ||
+                        (!transitState.transitSuccess && (currentPassword === '' || !areValidMatchingPasswords()))
+                    )
+                        return;
+                    void changePassword();
+                }}
+            >
                 <SecureTextField
                     id="current-password"
                     label={t('LABELS.CURRENT_PASSWORD')}
                     value={currentPassword}
                     onChange={(evt: ChangeEvent<HTMLInputElement>): void => setCurrentPassword(evt.target.value)}
+                    onKeyPress={(e): void => {
+                        if (e.key === 'Enter' && passwordRef.current) {
+                            passwordRef.current.focus();
+                        }
+                    }}
                 />
             </ChangePasswordForm>
         );

--- a/login-workflow/src/screens/ForgotPassword.tsx
+++ b/login-workflow/src/screens/ForgotPassword.tsx
@@ -143,6 +143,9 @@ export const ForgotPassword: React.FC = () => {
                     fullWidth
                     value={emailInput}
                     onChange={(evt: ChangeEvent<HTMLInputElement>): void => setEmailInput(evt.target.value)}
+                    onKeyPress={(e): void => {
+                        if (e.key === 'Enter' && canContinue()) onContinue();
+                    }}
                     variant="filled"
                     error={hasTransitError}
                     helperText={hasTransitError ? t('FORGOT_PASSWORD.ERROR') : ''}

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -253,13 +253,19 @@ export const InviteRegistrationPager: React.FC = () => {
                     />
                 );
             case Pages.CreatePassword:
-                return <CreatePasswordScreen onPasswordChanged={setPassword} initialPassword={password} />;
+                return (
+                    <CreatePasswordScreen
+                        onPasswordChanged={setPassword}
+                        initialPassword={password}
+                        onSubmit={canProgress() ? (): void => advancePage(1) : undefined}
+                    />
+                );
             case Pages.AccountDetails:
                 return (
                     <AccountDetailsScreen
                         onDetailsChanged={setAccountDetails}
                         initialDetails={accountDetails}
-                        onSubmit={canProgress ? (): void => advancePage(1) : undefined}
+                        onSubmit={canProgress() ? (): void => advancePage(1) : undefined}
                     />
                 );
             case Pages.Complete:

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -255,7 +255,13 @@ export const InviteRegistrationPager: React.FC = () => {
             case Pages.CreatePassword:
                 return <CreatePasswordScreen onPasswordChanged={setPassword} initialPassword={password} />;
             case Pages.AccountDetails:
-                return <AccountDetailsScreen onDetailsChanged={setAccountDetails} initialDetails={accountDetails} />;
+                return (
+                    <AccountDetailsScreen
+                        onDetailsChanged={setAccountDetails}
+                        initialDetails={accountDetails}
+                        onSubmit={canProgress ? (): void => advancePage(1) : undefined}
+                    />
+                );
             case Pages.Complete:
                 return (
                     <RegistrationComplete
@@ -272,6 +278,8 @@ export const InviteRegistrationPager: React.FC = () => {
                 return <></>;
         }
     }, [
+        advancePage,
+        canProgress,
         currentPage,
         eulaAccepted,
         setEulaAccepted,

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useCallback, useEffect } from 'react';
+import React, { ChangeEvent, useCallback, useEffect, useRef } from 'react';
 import { useRoutes } from '../contexts/RoutingContext';
 import {
     useSecurityState,
@@ -108,6 +108,8 @@ export const Login: React.FC = () => {
     const { routes } = useRoutes();
     const theme = useTheme();
     const classes = useStyles();
+
+    const passwordField = useRef<any>(null);
 
     // Local State
     const [rememberPassword, setRememberPassword] = React.useState(securityState.rememberMeDetails.rememberMe ?? false);
@@ -239,11 +241,15 @@ export const Login: React.FC = () => {
                         className={clsx(classes.formFields, { [classes.hasError]: hasTransitError })}
                         value={emailInput}
                         onChange={(evt: ChangeEvent<HTMLInputElement>): void => setEmailInput(evt.target.value)}
+                        onKeyPress={(e): void => {
+                            if (e.key === 'Enter' && passwordField.current) passwordField.current.focus();
+                        }}
                         variant="filled"
                         error={hasTransitError}
                         helperText={hasTransitError ? t('LOGIN.INCORRECT_CREDENTIALS') : ''}
                     />
                     <SecureTextField
+                        inputRef={passwordField}
                         id="password"
                         name="password"
                         label={t('LABELS.PASSWORD')}

--- a/login-workflow/src/screens/ResetPassword.tsx
+++ b/login-workflow/src/screens/ResetPassword.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, ChangeEvent } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
     useLanguageLocale,
     useAccountUIState,
@@ -10,7 +10,7 @@ import { useQueryString } from '../hooks/useQueryString';
 import { useRoutes } from '../contexts/RoutingContext';
 import { useHistory } from 'react-router-dom';
 import { CardHeader, Typography, CardContent, Divider, CardActions, Grid, Button, useTheme } from '@material-ui/core';
-import { BrandedCardContainer, SecureTextField, PasswordRequirements, SimpleDialog, FinishState } from '../components';
+import { BrandedCardContainer, SimpleDialog, FinishState, ChangePasswordForm } from '../components';
 import { defaultPasswordRequirements } from '../constants';
 import CheckCircle from '@material-ui/icons/CheckCircle';
 import Error from '@material-ui/icons/Error';
@@ -75,6 +75,14 @@ export const ResetPassword: React.FC = () => {
         return confirmInput === passwordInput;
     }, [passwordRequirements, passwordInput, confirmInput]);
 
+    const updateFields = useCallback(
+        (fields: { password: string; confirm: string }) => {
+            setPasswordInput(fields.password);
+            setConfirmInput(fields.confirm);
+        },
+        [setPasswordInput, setConfirmInput]
+    );
+
     const resetPassword = useCallback(
         (password: string): void => {
             void accountUIActions.actions.setPassword(code, password, email);
@@ -108,25 +116,8 @@ export const ResetPassword: React.FC = () => {
                 ) : (
                     <>
                         <Typography>{t('CHANGE_PASSWORD.PASSWORD_INFO')}</Typography>
-
                         <Divider className={classes.fullDivider} />
-
-                        <SecureTextField
-                            id="password"
-                            name="password"
-                            label={t('FORMS.PASSWORD')}
-                            value={passwordInput}
-                            onChange={(evt: ChangeEvent<HTMLInputElement>): void => setPasswordInput(evt.target.value)}
-                        />
-                        <PasswordRequirements style={{ marginTop: theme.spacing(2) }} passwordText={passwordInput} />
-                        <SecureTextField
-                            id="confirm"
-                            name="confirm"
-                            label={t('FORMS.CONFIRM_PASSWORD')}
-                            className={classes.textField}
-                            value={confirmInput}
-                            onChange={(evt: ChangeEvent<HTMLInputElement>): void => setConfirmInput(evt.target.value)}
-                        />
+                        <ChangePasswordForm passwordLabel={t('LABELS.NEW_PASSWORD')} onPasswordChange={updateFields} />
                     </>
                 )
             ) : !verifyComplete ? (
@@ -142,15 +133,12 @@ export const ResetPassword: React.FC = () => {
             t,
             theme,
             classes,
-            passwordInput,
-            setPasswordInput,
-            confirmInput,
-            setConfirmInput,
             verifySuccess,
             verifyIsInTransit,
             verifyComplete,
             validationTransitErrorMessage,
             setPasswordTransitSuccess,
+            updateFields,
         ]
     );
 

--- a/login-workflow/src/screens/ResetPassword.tsx
+++ b/login-workflow/src/screens/ResetPassword.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
     useLanguageLocale,
     useAccountUIState,
@@ -30,6 +30,9 @@ export const ResetPassword: React.FC = () => {
     const accountUIState = useAccountUIState();
     const accountUIActions = useAccountUIActions();
     const { code, email } = useQueryString();
+
+    const passwordRef = useRef(null);
+    const confirmRef = useRef(null);
 
     // Local State
     const [passwordInput, setPasswordInput] = useState('');
@@ -114,11 +117,13 @@ export const ResetPassword: React.FC = () => {
                         description={t('CHANGE_PASSWORD.SUCCESS_MESSAGE')}
                     />
                 ) : (
-                    <>
-                        <Typography>{t('CHANGE_PASSWORD.PASSWORD_INFO')}</Typography>
-                        <Divider className={classes.fullDivider} />
-                        <ChangePasswordForm passwordLabel={t('LABELS.NEW_PASSWORD')} onPasswordChange={updateFields} />
-                    </>
+                    <ChangePasswordForm
+                        passwordRef={passwordRef}
+                        confirmRef={confirmRef}
+                        passwordLabel={t('LABELS.NEW_PASSWORD')}
+                        onPasswordChange={updateFields}
+                        onSubmit={canContinue() ? onContinue : undefined}
+                    />
                 )
             ) : !verifyComplete ? (
                 <></>
@@ -131,8 +136,9 @@ export const ResetPassword: React.FC = () => {
             ),
         [
             t,
+            canContinue,
+            onContinue,
             theme,
-            classes,
             verifySuccess,
             verifyIsInTransit,
             verifyComplete,

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -331,7 +331,7 @@ export const SelfRegistrationPager: React.FC = () => {
                     <CreateAccountScreen
                         initialEmail={email}
                         onEmailChanged={setEmail}
-                        onSubmit={canProgress ? (): void => advancePage(1) : undefined}
+                        onSubmit={canProgress() ? (): void => advancePage(1) : undefined}
                     />
                 );
             case Pages.Eula:
@@ -353,13 +353,25 @@ export const SelfRegistrationPager: React.FC = () => {
                         onResendVerificationEmail={(): void => {
                             void requestCode();
                         }}
-                        onSubmit={canProgress ? (): void => advancePage(1) : undefined}
+                        onSubmit={canProgress() ? (): void => advancePage(1) : undefined}
                     />
                 );
             case Pages.CreatePassword:
-                return <CreatePasswordScreen onPasswordChanged={setPassword} initialPassword={password} />;
+                return (
+                    <CreatePasswordScreen
+                        onPasswordChanged={setPassword}
+                        initialPassword={password}
+                        onSubmit={canProgress() ? (): void => advancePage(1) : undefined}
+                    />
+                );
             case Pages.AccountDetails:
-                return <AccountDetailsScreen onDetailsChanged={setAccountDetails} initialDetails={accountDetails} />;
+                return (
+                    <AccountDetailsScreen
+                        onDetailsChanged={setAccountDetails}
+                        initialDetails={accountDetails}
+                        onSubmit={canProgress() ? (): void => advancePage(1) : undefined}
+                    />
+                );
             case Pages.Complete:
                 return (
                     <RegistrationComplete

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -327,7 +327,13 @@ export const SelfRegistrationPager: React.FC = () => {
         }
         switch (currentPage) {
             case Pages.CreateAccount:
-                return <CreateAccountScreen initialEmail={email} onEmailChanged={setEmail} />;
+                return (
+                    <CreateAccountScreen
+                        initialEmail={email}
+                        onEmailChanged={setEmail}
+                        onSubmit={canProgress ? (): void => advancePage(1) : undefined}
+                    />
+                );
             case Pages.Eula:
                 return (
                     <AcceptEula
@@ -347,6 +353,7 @@ export const SelfRegistrationPager: React.FC = () => {
                         onResendVerificationEmail={(): void => {
                             void requestCode();
                         }}
+                        onSubmit={canProgress ? (): void => advancePage(1) : undefined}
                     />
                 );
             case Pages.CreatePassword:
@@ -369,6 +376,8 @@ export const SelfRegistrationPager: React.FC = () => {
                 return <></>;
         }
     }, [
+        advancePage,
+        canProgress,
         currentPage,
         setEmail,
         eulaAccepted,

--- a/login-workflow/src/screens/subScreens/AccountDetails.tsx
+++ b/login-workflow/src/screens/subScreens/AccountDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { TextField, Typography, Divider } from '@material-ui/core';
 import { useLanguageLocale, AccountDetailInformation } from '@pxblue/react-auth-shared';
 import { useDialogStyles } from '../../styles';
@@ -6,6 +6,7 @@ import { useDialogStyles } from '../../styles';
 export type AccountDetailsProps = {
     onDetailsChanged: (details: (AccountDetailInformation & { valid: boolean }) | null) => void;
     initialDetails?: AccountDetailInformation;
+    onSubmit?: () => void;
 };
 
 /**
@@ -13,13 +14,17 @@ export type AccountDetailsProps = {
  *
  * @param initialDetails an object specifying any details to pre-fill
  * @param onDetailsChanged a function to call when any of the detail fields values change
- *
+ * @param onSubmit function to call when the user submits the mini form
  * @category Component
  */
 export const AccountDetails: React.FC<AccountDetailsProps> = (props) => {
-    const { onDetailsChanged, initialDetails } = props;
+    const { onDetailsChanged, initialDetails, onSubmit } = props;
     const classes = useDialogStyles();
     const { t } = useLanguageLocale();
+
+    const firstRef = useRef<any>(null);
+    const lastRef = useRef<any>(null);
+    const phoneRef = useRef<any>(null);
 
     const [firstNameInput, setFirstNameInput] = React.useState(initialDetails ? initialDetails.firstName : '');
     const [lastNameInput, setLastNameInput] = React.useState(initialDetails ? initialDetails.lastName : '');
@@ -36,6 +41,7 @@ export const AccountDetails: React.FC<AccountDetailsProps> = (props) => {
             <Typography>{t('REGISTRATION.INSTRUCTIONS.ACCOUNT_DETAILS')}</Typography>
             <Divider className={classes.fullDivider} />
             <TextField
+                inputRef={firstRef}
                 id="first"
                 label={t('FORMS.FIRST_NAME')}
                 fullWidth
@@ -43,9 +49,13 @@ export const AccountDetails: React.FC<AccountDetailsProps> = (props) => {
                 onChange={(evt): void => {
                     setFirstNameInput(evt.target.value);
                 }}
+                onKeyPress={(e): void => {
+                    if (e.key === 'Enter' && lastRef.current) lastRef.current.focus();
+                }}
                 variant="filled"
             />
             <TextField
+                inputRef={lastRef}
                 id="last"
                 label={t('FORMS.LAST_NAME')}
                 fullWidth
@@ -53,16 +63,23 @@ export const AccountDetails: React.FC<AccountDetailsProps> = (props) => {
                 onChange={(evt): void => {
                     setLastNameInput(evt.target.value);
                 }}
+                onKeyPress={(e): void => {
+                    if (e.key === 'Enter' && phoneRef.current) phoneRef.current.focus();
+                }}
                 variant="filled"
                 className={classes.textField}
             />
             <TextField
+                inputRef={phoneRef}
                 id="phone"
                 label={`${t('FORMS.PHONE_NUMBER')} (${t('LABELS.OPTIONAL')})`}
                 fullWidth
                 value={phoneInput}
                 onChange={(evt): void => {
                     setPhoneInput(evt.target.value);
+                }}
+                onKeyPress={(e): void => {
+                    if (e.key === 'Enter' && onSubmit) onSubmit();
                 }}
                 variant="filled"
                 className={classes.textField}

--- a/login-workflow/src/screens/subScreens/CreateAccount.tsx
+++ b/login-workflow/src/screens/subScreens/CreateAccount.tsx
@@ -8,6 +8,7 @@ const isValidEmail = (text: string): boolean => new RegExp(EMAIL_REGEX).test(tex
 export type CreateAccountProps = {
     initialEmail?: string;
     onEmailChanged: (email: string) => void;
+    onSubmit?: () => void;
 };
 
 /**
@@ -16,11 +17,12 @@ export type CreateAccountProps = {
  *
  * @param initialEmail email address used to pre-fill the text field
  * @param onEmailChanged function to call when the value of the email input changes
+ * @param onSubmit function to call when the user submits the mini form
  *
  * @category Component
  */
 export const CreateAccount: React.FC<CreateAccountProps> = (props) => {
-    const { initialEmail, onEmailChanged } = props;
+    const { initialEmail, onEmailChanged, onSubmit } = props;
     const classes = useDialogStyles();
     const { t } = useLanguageLocale();
 
@@ -41,6 +43,9 @@ export const CreateAccount: React.FC<CreateAccountProps> = (props) => {
                     setEmailInput(evt.target.value);
                     const validEmailOrEmpty = isValidEmail(evt.target.value) ? evt.target.value : '';
                     onEmailChanged(validEmailOrEmpty);
+                }}
+                onKeyPress={(e): void => {
+                    if (e.key === 'Enter' && onSubmit) onSubmit();
                 }}
                 variant="filled"
                 error={showEmailError}

--- a/login-workflow/src/screens/subScreens/CreatePassword.tsx
+++ b/login-workflow/src/screens/subScreens/CreatePassword.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { useLanguageLocale, useInjectedUIContext } from '@pxblue/react-auth-shared';
 import { ChangePasswordForm } from '../../components';
 import { defaultPasswordRequirements } from '../../constants';
@@ -6,6 +6,7 @@ import { defaultPasswordRequirements } from '../../constants';
 export type CreatePasswordProps = {
     onPasswordChanged: (password: string) => void;
     initialPassword?: string;
+    onSubmit?: () => void;
 };
 
 /**
@@ -13,12 +14,16 @@ export type CreatePasswordProps = {
  *
  * @param initialPassword value to pre-populate the password and confirmation fields
  * @param onPasswordChanged function to call when the password or confirm fields change
+ * @param onSubmit function to call when the mini form is submitted
  *
  * @category Component
  */
 export const CreatePassword: React.FC<CreatePasswordProps> = (props) => {
-    const { onPasswordChanged, initialPassword = '' } = props;
+    const { onPasswordChanged, initialPassword = '', onSubmit } = props;
     const { t } = useLanguageLocale();
+
+    const passwordRef = useRef(null);
+    const confirmRef = useRef(null);
 
     const [passwordInput, setPasswordInput] = useState(initialPassword);
     const [confirmInput, setConfirmInput] = useState(initialPassword);
@@ -44,5 +49,12 @@ export const CreatePassword: React.FC<CreatePasswordProps> = (props) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [onPasswordChanged, passwordInput, confirmInput, areValidMatchingPasswords]);
 
-    return <ChangePasswordForm onPasswordChange={updateFields} />;
+    return (
+        <ChangePasswordForm
+            passwordRef={passwordRef}
+            confirmRef={confirmRef}
+            onPasswordChange={updateFields}
+            onSubmit={onSubmit}
+        />
+    );
 };

--- a/login-workflow/src/screens/subScreens/CreatePassword.tsx
+++ b/login-workflow/src/screens/subScreens/CreatePassword.tsx
@@ -1,9 +1,7 @@
-import React, { useState, useCallback, ChangeEvent, useEffect } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { useLanguageLocale, useInjectedUIContext } from '@pxblue/react-auth-shared';
-import { Typography, Divider, useTheme } from '@material-ui/core';
-import { SecureTextField, PasswordRequirements } from '../../components';
+import { ChangePasswordForm } from '../../components';
 import { defaultPasswordRequirements } from '../../constants';
-import { useDialogStyles } from '../../styles';
 
 export type CreatePasswordProps = {
     onPasswordChanged: (password: string) => void;
@@ -20,8 +18,6 @@ export type CreatePasswordProps = {
  */
 export const CreatePassword: React.FC<CreatePasswordProps> = (props) => {
     const { onPasswordChanged, initialPassword = '' } = props;
-    const theme = useTheme();
-    const classes = useDialogStyles();
     const { t } = useLanguageLocale();
 
     const [passwordInput, setPasswordInput] = useState(initialPassword);
@@ -35,32 +31,18 @@ export const CreatePassword: React.FC<CreatePasswordProps> = (props) => {
         return confirmInput === passwordInput;
     }, [passwordRequirements, passwordInput, confirmInput]);
 
+    const updateFields = useCallback(
+        (fields: { password: string; confirm: string }) => {
+            setPasswordInput(fields.password);
+            setConfirmInput(fields.confirm);
+        },
+        [setPasswordInput, setConfirmInput]
+    );
+
     useEffect(() => {
         onPasswordChanged(areValidMatchingPasswords() ? passwordInput : '');
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [onPasswordChanged, passwordInput, confirmInput, areValidMatchingPasswords]);
 
-    return (
-        <>
-            <Typography>{t('CHANGE_PASSWORD.PASSWORD_INFO')}</Typography>
-            <Divider className={classes.fullDivider} />
-            <SecureTextField
-                id="password"
-                name="password"
-                label={t('FORMS.PASSWORD')}
-                value={passwordInput}
-                onChange={(evt: ChangeEvent<HTMLInputElement>): void => setPasswordInput(evt.target.value)}
-            />
-            <PasswordRequirements style={{ marginTop: theme.spacing(2) }} passwordText={passwordInput} />
-            <SecureTextField
-                id="confirm"
-                name="confirm"
-                label={t('FORMS.CONFIRM_PASSWORD')}
-                className={classes.textField}
-                value={confirmInput}
-                onChange={(evt: ChangeEvent<HTMLInputElement>): void => setConfirmInput(evt.target.value)}
-                error={confirmInput !== '' && passwordInput !== confirmInput}
-            />
-        </>
-    );
+    return <ChangePasswordForm onPasswordChange={updateFields} />;
 };

--- a/login-workflow/src/screens/subScreens/VerifyEmail.tsx
+++ b/login-workflow/src/screens/subScreens/VerifyEmail.tsx
@@ -7,6 +7,7 @@ export type VerifyEmailProps = {
     initialCode?: string;
     onVerifyCodeChanged: (code: string) => void;
     onResendVerificationEmail: () => void;
+    onSubmit?: () => void;
 };
 
 /**
@@ -16,11 +17,12 @@ export type VerifyEmailProps = {
  * @param initialCode code used to pre-populate the field
  * @param onVerifyCodeChanged function to call when the code input value changes
  * @param onResendVerificationEmail function to call when the user clicks the 'resend code' button
+ * @param onSubmit function to call when the user submits the mini form
  *
  * @category Component
  */
 export const VerifyEmail: React.FC<VerifyEmailProps> = (props) => {
-    const { initialCode, onVerifyCodeChanged, onResendVerificationEmail } = props;
+    const { initialCode, onVerifyCodeChanged, onResendVerificationEmail, onSubmit } = props;
     const theme = useTheme();
     const classes = useDialogStyles();
     const { t } = useLanguageLocale();
@@ -46,6 +48,9 @@ export const VerifyEmail: React.FC<VerifyEmailProps> = (props) => {
                 value={verifyCode}
                 onChange={(evt): void => {
                     setVerifyCode(evt.target.value);
+                }}
+                onKeyPress={(e): void => {
+                    if (e.key === 'Enter' && onSubmit) onSubmit();
                 }}
                 variant="filled"
             />


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #18 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Enter key will transition between fields on a screen
- Enter key on the last input field will submit the form (go to next screen usually)
- Converted some screens to use the reusable password form component

> ~~None of the screens that have a password component have this behavior yet (Change Password, Reset Password, Create Password). I ran into some issues getting the refs to work correctly with the reusable password component. Will address those in a follow-up PR.~~

All screens should be working correctly now.