### PR TITLE
React workflow fixes

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Issue with login function being called twice ([#70](https://github.com/pxblue/react-workflows/issues/70)).
+-   Issue with disabled back button at certain points in the registration workflows.
+
+### Changed
+
+-   EULA page order in the self registration workflow.
+
+### Added
+
+-   Ability to to customize the character limits for first and last name text fields in the registration workflow via the `registrationConfig` prop on the `AuthUIContextProvider`.
 
 ## v2.2.0 (June 28, 2021)
 

--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -10,16 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Issue with login function being called twice ([#70](https://github.com/pxblue/react-workflows/issues/70)).
--   Issue with disabled back button at certain points in the registration workflows.
--   Issue where "Invalid Credentials" error message would persist on login screen.
+-   Issue where "Invalid Credentials" error message would persist on login screen([#67](https://github.com/pxblue/react-workflows/issues/67)).
 
 ### Changed
 
--   EULA page order in the self registration workflow.
+-   EULA screen now appears first in the self registration workflow.
+-   Allow users to go back at all steps of the registration flow.
 
 ### Added
 
--   Ability to customize the character limits for first and last name text fields in the registration workflow via the `registrationConfig` prop on the `AuthUIContextProvider`.
+-   Ability to customize the character limits for first and last name text fields in the registration workflow via the `registrationConfig` prop on the `AuthUIContextProvider` ([#72](https://github.com/pxblue/react-workflows/issues/72)).
 
 ## v2.2.0 (June 28, 2021)
 

--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v2.3.0 (Unpublished)
+## v2.3.0 (July 21, 2021)
 
 ### Fixed
 

--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Issue with login function being called twice ([#70](https://github.com/pxblue/react-workflows/issues/70)).
 -   Issue with disabled back button at certain points in the registration workflows.
+-   Issue where "Invalid Credentials" error message would persist on login screen.
 
 ### Changed
 

--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   Ability to to customize the character limits for first and last name text fields in the registration workflow via the `registrationConfig` prop on the `AuthUIContextProvider`.
+-   Ability to customize the character limits for first and last name text fields in the registration workflow via the `registrationConfig` prop on the `AuthUIContextProvider`.
 
 ## v2.2.0 (June 28, 2021)
 

--- a/login-workflow/example/src/App.tsx
+++ b/login-workflow/example/src/App.tsx
@@ -94,8 +94,12 @@ export const AuthUIConfiguration: React.FC = (props) => {
             // )}
             // accountAlreadyExistsScreen={(): JSX.Element => <CustomAccountAlreadyExistsScreen />}
             // registrationConfig={{
-            //     firstNameLengthLimit: 30,
-            //     lastNameLengthLimit: 30,
+            //     firstName: {
+            //         maxLength: 30,
+            //     },
+            //     lastName: {
+            //         maxLength: 30,
+            //     },
             // }}
         >
             {props.children}

--- a/login-workflow/example/src/App.tsx
+++ b/login-workflow/example/src/App.tsx
@@ -79,7 +79,6 @@ export const AuthUIConfiguration: React.FC = (props) => {
                     </Button>
                 </div>
             }
-
             // loginType={'username'}
             // Uncomment this line to see how to add custom form fields to the registration screens
             // customAccountDetails={[
@@ -94,6 +93,10 @@ export const AuthUIConfiguration: React.FC = (props) => {
             //     <CustomRegistrationSuccessScreen registrationData={registrationData} />
             // )}
             // accountAlreadyExistsScreen={(): JSX.Element => <CustomAccountAlreadyExistsScreen />}
+            // registrationConfig={{
+            //     firstNameLengthLimit: 30,
+            //     lastNameLengthLimit: 30,
+            // }}
         >
             {props.children}
         </AuthUIContextProvider>

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pxblue/react-auth-workflow",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "author": "Power Xpert Blue <pxblue@eaton.com> (https://github.com/pxblue)",
     "license": "BSD-3-Clause",
     "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -25,7 +25,7 @@
     "prettier": "@pxblue/prettier-config",
     "dependencies": {
         "i18next-browser-languagedetector": "^6.1.0",
-        "@pxblue/react-auth-shared": "^3.3.0-beta.0",
+        "@pxblue/react-auth-shared": "^3.4.0",
         "dompurify": "^2.2.9"
     },
     "peerDependencies": {

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -363,7 +363,7 @@ export const InviteRegistrationPager: React.FC = () => {
                         onClick={(): void => advancePage(-1)}
                         className={sharedClasses.dialogButton}
                     >
-                        {t('pxb:ACTIONS.BACK')}
+                        {isFirstStep ? t('pxb:ACTIONS.CANCEL') : t('pxb:ACTIONS.BACK')}
                     </Button>
                 }
                 nextButton={

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -180,7 +180,7 @@ export const InviteRegistrationPager: React.FC = () => {
                 />
             ),
             canGoForward: eulaAccepted,
-            canGoBack: false,
+            canGoBack: true,
         },
         {
             name: 'CreatePassword',

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -316,7 +316,8 @@ export const Login: React.FC = () => {
                             const { value } = evt.target;
                             setIsValidEmail(EMAIL_REGEX.test(value));
                             setEmailInput(value);
-                            authUIState.login.transitErrorMessage = null;
+                            if (authUIState.login.transitErrorMessage !== null)
+                                authUIActions.dispatch(AccountActions.resetLogin());
                         }}
                         onKeyPress={(e): void => {
                             if (e.key === 'Enter' && passwordField.current) passwordField.current.focus();
@@ -337,7 +338,8 @@ export const Login: React.FC = () => {
                         value={passwordInput}
                         onChange={(evt: ChangeEvent<HTMLInputElement>): void => {
                             setPasswordInput(evt.target.value);
-                            authUIState.login.transitErrorMessage = null;
+                            if (authUIState.login.transitErrorMessage !== null)
+                                authUIActions.dispatch(AccountActions.resetLogin());
                         }}
                         variant="filled"
                         error={isInvalidCredentials}

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -316,6 +316,7 @@ export const Login: React.FC = () => {
                             const { value } = evt.target;
                             setIsValidEmail(EMAIL_REGEX.test(value));
                             setEmailInput(value);
+                            authUIState.login.transitErrorMessage = null;
                         }}
                         onKeyPress={(e): void => {
                             if (e.key === 'Enter' && passwordField.current) passwordField.current.focus();
@@ -334,7 +335,10 @@ export const Login: React.FC = () => {
                         label={t('pxb:LABELS.PASSWORD')}
                         className={clsx(classes.passwordFormField, { [classes.hasError]: isInvalidCredentials })}
                         value={passwordInput}
-                        onChange={(evt: ChangeEvent<HTMLInputElement>): void => setPasswordInput(evt.target.value)}
+                        onChange={(evt: ChangeEvent<HTMLInputElement>): void => {
+                            setPasswordInput(evt.target.value);
+                            authUIState.login.transitErrorMessage = null;
+                        }}
                         variant="filled"
                         error={isInvalidCredentials}
                         helperText={isInvalidCredentials ? t('pxb:LOGIN.INCORRECT_CREDENTIALS') : ''}

--- a/login-workflow/src/screens/Screens.test.tsx
+++ b/login-workflow/src/screens/Screens.test.tsx
@@ -74,8 +74,15 @@ describe('AcceptEula tests', () => {
 describe('AccountDetails tests', () => {
     it('renders without crashing', () => {
         const div = document.createElement('div');
+        const authUIActions = jest.fn();
+        const registrationUIActions = jest.fn();
         const onDetailsChanged = jest.fn();
-        ReactDOM.render(<AccountDetails onDetailsChanged={onDetailsChanged} />, div);
+        ReactDOM.render(
+            <AuthUIContextProvider authActions={authUIActions} registrationActions={registrationUIActions}>
+                <AccountDetails onDetailsChanged={onDetailsChanged} />
+            </AuthUIContextProvider>,
+            div
+        );
         ReactDOM.unmountComponentAtNode(div);
     });
 });

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -205,20 +205,6 @@ export const SelfRegistrationPager: React.FC = () => {
 
     const RegistrationPages: RegistrationPage[] = [
         {
-            name: 'CreateAccount',
-            pageTitle: t('pxb:REGISTRATION.STEPS.CREATE_ACCOUNT'),
-            pageBody: (
-                <CreateAccountScreen
-                    initialEmail={email}
-                    onEmailChanged={setEmail}
-                    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-                    onSubmit={email.length > 0 ? (): void => advancePage(1) : undefined}
-                />
-            ),
-            canGoForward: email.length > 0,
-            canGoBack: true,
-        },
-        {
             name: 'Eula',
             pageTitle: t('pxb:REGISTRATION.STEPS.LICENSE'),
             pageBody: (
@@ -232,6 +218,20 @@ export const SelfRegistrationPager: React.FC = () => {
                 />
             ),
             canGoForward: eulaAccepted,
+            canGoBack: true,
+        },
+        {
+            name: 'CreateAccount',
+            pageTitle: t('pxb:REGISTRATION.STEPS.CREATE_ACCOUNT'),
+            pageBody: (
+                <CreateAccountScreen
+                    initialEmail={email}
+                    onEmailChanged={setEmail}
+                    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                    onSubmit={email.length > 0 ? (): void => advancePage(1) : undefined}
+                />
+            ),
+            canGoForward: email.length > 0,
             canGoBack: true,
         },
         {

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -249,7 +249,7 @@ export const SelfRegistrationPager: React.FC = () => {
                 />
             ),
             canGoForward: verificationCode.length > 0,
-            canGoBack: false,
+            canGoBack: true,
         },
         {
             name: 'CreatePassword',
@@ -263,7 +263,7 @@ export const SelfRegistrationPager: React.FC = () => {
                 />
             ),
             canGoForward: password.length > 0,
-            canGoBack: false,
+            canGoBack: true,
         },
         {
             name: 'AccountDetails',

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -359,7 +359,7 @@ export const SelfRegistrationPager: React.FC = () => {
         ]);
     const isLastStep = currentPage === RegistrationPages.length - 1;
     const isFirstStep = currentPage === 0;
-    const EulaPage = RegistrationPages.findIndex((item) => item.name === 'Eula');
+    const CreateAccountPage = RegistrationPages.findIndex((item) => item.name === 'CreateAccount');
     const VerifyEmailPage = RegistrationPages.findIndex((item) => item.name === 'VerifyEmail');
     const CreatePasswordPage = RegistrationPages.findIndex((item) => item.name === 'CreatePassword');
     const CompletePage = RegistrationPages.length - 1;
@@ -381,7 +381,7 @@ export const SelfRegistrationPager: React.FC = () => {
 
     // If the verification code is sent successfully, go to the confirmation page
     useEffect(() => {
-        if (currentPage === EulaPage && codeRequestSuccess) {
+        if (currentPage === CreateAccountPage && codeRequestSuccess) {
             setCurrentPage(VerifyEmailPage);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -411,7 +411,7 @@ export const SelfRegistrationPager: React.FC = () => {
             // Check > 0 so advancing backwards does not risk going into the completion block
             if (currentPage === RegistrationPages.length - 2 && !registrationSuccess && canProgress() && delta > 0) {
                 void attemptRegistration();
-            } else if (currentPage === EulaPage && !codeRequestIsInTransit && canProgress() && delta > 0) {
+            } else if (currentPage === CreateAccountPage && !codeRequestIsInTransit && canProgress() && delta > 0) {
                 void requestCode();
             } else if (currentPage === VerifyEmailPage && !isValidationInTransit && canProgress() && delta > 0) {
                 void validateCode();

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -438,7 +438,7 @@ export const SelfRegistrationPager: React.FC = () => {
                 disableElevation
                 onClick={(): void => history.push(routes.LOGIN)}
             >
-                {t('pxb:ACTIONS.CONTINUE')}
+                {isFirstStep ? t('pxb:ACTIONS.CANCEL') : t('pxb:ACTIONS.BACK')}
             </Button>
         );
     } else if (isLastStep) {
@@ -468,7 +468,7 @@ export const SelfRegistrationPager: React.FC = () => {
                         onClick={(): void => advancePage(-1)}
                         className={sharedClasses.dialogButton}
                     >
-                        {t('pxb:ACTIONS.BACK')}
+                        {isFirstStep ? t('pxb:ACTIONS.CANCEL') : t('pxb:ACTIONS.BACK')}
                     </Button>
                 }
                 nextButton={

--- a/login-workflow/src/screens/subScreens/AccountDetails.tsx
+++ b/login-workflow/src/screens/subScreens/AccountDetails.tsx
@@ -51,7 +51,8 @@ export const AccountDetails: React.FC<AccountDetailsProps> = (props) => {
     const [firstNameInput, setFirstNameInput] = React.useState(initialDetails ? initialDetails.firstName : '');
     const [lastNameInput, setLastNameInput] = React.useState(initialDetails ? initialDetails.lastName : '');
 
-    const { firstNameLengthLimit, lastNameLengthLimit } = useInjectedUIContext().registrationConfig || {};
+    const firstNameLengthLimit = useInjectedUIContext()?.registrationConfig?.firstName?.maxLength || null;
+    const lastNameLengthLimit = useInjectedUIContext()?.registrationConfig?.lastName?.maxLength || null;
 
     useEffect((): void => {
         // validation checks

--- a/login-workflow/src/screens/subScreens/AccountDetails.tsx
+++ b/login-workflow/src/screens/subScreens/AccountDetails.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { TextField, Typography, Divider } from '@material-ui/core';
-import { useLanguageLocale, AccountDetailInformation } from '@pxblue/react-auth-shared';
+import { useLanguageLocale, AccountDetailInformation, useInjectedUIContext } from '@pxblue/react-auth-shared';
 import { useDialogStyles } from '../../styles';
 
 export type AccountDetailsWrapperProps = {
@@ -51,6 +51,8 @@ export const AccountDetails: React.FC<AccountDetailsProps> = (props) => {
     const [firstNameInput, setFirstNameInput] = React.useState(initialDetails ? initialDetails.firstName : '');
     const [lastNameInput, setLastNameInput] = React.useState(initialDetails ? initialDetails.lastName : '');
 
+    const { firstNameLengthLimit, lastNameLengthLimit } = useInjectedUIContext().registrationConfig || {};
+
     useEffect((): void => {
         // validation checks
         const valid = firstNameInput !== '' && lastNameInput !== '';
@@ -72,6 +74,7 @@ export const AccountDetails: React.FC<AccountDetailsProps> = (props) => {
                     if (e.key === 'Enter' && lastRef.current) lastRef.current.focus();
                 }}
                 variant="filled"
+                inputProps={{ maxLength: firstNameLengthLimit }}
             />
             <TextField
                 inputRef={lastRef}
@@ -87,6 +90,7 @@ export const AccountDetails: React.FC<AccountDetailsProps> = (props) => {
                 }}
                 variant="filled"
                 className={classes.textField}
+                inputProps={{ maxLength: lastNameLengthLimit }}
             />
         </>
     );

--- a/login-workflow/yarn.lock
+++ b/login-workflow/yarn.lock
@@ -1305,10 +1305,10 @@
   resolved "https://registry.yarnpkg.com/@pxblue/prettier-config/-/prettier-config-1.0.3.tgz#285b9ba346f714d397ef4a59579443b95a77e63e"
   integrity sha512-x9SDup4pf5H54r/stZBXz7/XlMcIqnwHkEJ+9pyXVtGyQljI28lDGQCWQj6heipWAett50yx0RB3P2+MWZDhJA==
 
-"@pxblue/react-auth-shared@^3.3.0-beta.0":
-  version "3.3.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@pxblue/react-auth-shared/-/react-auth-shared-3.3.0-beta.0.tgz#bf0342e413645e6156e1ebf8bdafe25d5d99f89c"
-  integrity sha512-thLm+9Wa/e6chBMWnrI1BCsKPOH9sMZSbfpvTxjaMT/Paf+TQvZYeVv/gmwYA2suzj7Qvv8Ad1EqlPxJvtDYyQ==
+"@pxblue/react-auth-shared@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@pxblue/react-auth-shared/-/react-auth-shared-3.4.0.tgz#cfa80ed761e22ec8109b166dd53d6e0e35c47b51"
+  integrity sha512-O9iCUW2NpxcAs9RJmlQwXdnvFIMzjN+OXhqbE0b+cleIJugHs4rV/8Zm1UneT8PyK6zsEeMwdI+SFG3F2j19UQ==
 
 "@pxblue/react-components@^5.2.0":
   version "5.2.0"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes PXBLUE-2255, #72, and #67.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Allow users to go back during all steps in the account registration workflows
- Changed EULA page order so it shows first during self registration
- Add ability to customize character limits for first and last name text fields
- Clear Invalid credentials error message after editing input

** Use shared-auth branch `feature/add-name-character-limits` to test these.

To test the custom character limit, uncomment the `registrationConfig` definition in the `AuthUIContextProvider` in the example project's `App.tsx` file.

To test invalid credentials error message, edit the example project's `AuthUIActions.tsx` login method to immediately return `throw new Error('LOGIN.INVALID_CREDENTIALS');`. Start up example project and try to login. The "Invalid credentials" error should display on the email and password inputs. Modify either input and observe the error being removed until submitting and receiving another transit error.
