### PR TITLE
Add ability to customize how login error messages are displayed

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.4.0 (unreleased)
+
+### Added
+
+-   Ability to customize how error messages are displayed on the login screen via the `loginErrorDisplayConfig` prop on the `AuthUIContextProvider`.
+
 ## v2.3.0 (July 21, 2021)
 
 ### Fixed

--- a/login-workflow/example/src/actions/AuthUIActions.tsx
+++ b/login-workflow/example/src/actions/AuthUIActions.tsx
@@ -87,7 +87,6 @@ export const ProjectAuthUIActions: AuthUIActionsWithSecurity = (securityHelper) 
     logIn: async (email: string, password: string, rememberMe: boolean): Promise<void> => {
         await sleep(1000);
 
-        throw new Error('LOGIN.INVALID_CREDENTIALS');
         // throw new Error('My Custom Error');
 
         if (isRandomFailure()) {

--- a/login-workflow/example/src/actions/AuthUIActions.tsx
+++ b/login-workflow/example/src/actions/AuthUIActions.tsx
@@ -87,6 +87,7 @@ export const ProjectAuthUIActions: AuthUIActionsWithSecurity = (securityHelper) 
     logIn: async (email: string, password: string, rememberMe: boolean): Promise<void> => {
         await sleep(1000);
 
+        throw new Error('LOGIN.INVALID_CREDENTIALS');
         // throw new Error('My Custom Error');
 
         if (isRandomFailure()) {

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -26,7 +26,7 @@
     "prettier": "@pxblue/prettier-config",
     "dependencies": {
         "i18next-browser-languagedetector": "^6.1.0",
-        "@pxblue/react-auth-shared": "^3.4.0",
+        "@pxblue/react-auth-shared": "^3.5.0-beta.0",
         "dompurify": "^2.2.9"
     },
     "peerDependencies": {

--- a/login-workflow/scripts/linkWorkflow.sh
+++ b/login-workflow/scripts/linkWorkflow.sh
@@ -9,9 +9,21 @@ BGREEN='\033[1;32m' #BOLD
 GRAY='\033[1;30m'
 NC='\033[0m' # No Color
 
+echo -e "${BLUE}Building auth-shared package...${NC}"
+cd ./shared-auth && yarn build && cd ..
+
+echo -en "${BLUE}Creating new folder in login-workflow node_modules...${NC}"
+rm -rf "./node_modules/@pxblue/react-auth-shared"
+mkdir -p "./node_modules/@pxblue/react-auth-shared"
+echo -e "${GREEN}Done${NC}"
+
+echo -en "${BLUE}Copying auth-shared build output into node_modules...${NC}";
+cp -r ./shared-auth/package.json ./node_modules/@pxblue/react-auth-shared/package.json
+cp -r ./shared-auth/lib/. ./node_modules/@pxblue/react-auth-shared/lib
+echo -e "${GREEN}Done${NC}"
+
 echo -e "${BLUE}Building workflow package...${NC}"
 yarn build
-cd ./shared-auth && yarn build && cd ..
 
 echo -en "${BLUE}Creating new folder in node_modules...${NC}"
 rm -rf "./example/node_modules/@pxblue/react-auth-workflow"

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -62,19 +62,22 @@ const useStyles = makeStyles((theme: Theme) =>
             },
         },
         errorMessageBox: {
-            display: 'flex',
             width: '100%',
-            backgroundColor: (props: LoginErrorDisplayConfig) => props.backgroundColor || theme.palette.error.main,
+            backgroundColor: (loginErrorDisplayConfig: LoginErrorDisplayConfig) =>
+                loginErrorDisplayConfig.backgroundColor || theme.palette.error.main,
             borderRadius: 4,
             padding: 16,
-            color: (props: LoginErrorDisplayConfig) => props.fontColor || Colors.white[50],
+            color: (loginErrorDisplayConfig: LoginErrorDisplayConfig) =>
+                loginErrorDisplayConfig.fontColor || Colors.white[50],
             marginBottom: 16,
-            marginTop: (props: LoginErrorDisplayConfig) => (props.position !== 'bottom' ? 0 : -24),
+            marginTop: (loginErrorDisplayConfig: LoginErrorDisplayConfig) =>
+                loginErrorDisplayConfig.position !== 'bottom' ? 0 : theme.spacing(-1),
         },
         errorBoxDismissIcon: {
             '&:hover': {
                 cursor: 'pointer',
             },
+            float: 'right',
         },
         cyberBadge: {
             alignSelf: 'center',
@@ -231,9 +234,6 @@ export const Login: React.FC = () => {
     const errorMessageBox: JSX.Element =
         hasTransitError && transitErrorMessage && showErrorMessageBox ? (
             <div className={classes.errorMessageBox}>
-                <Typography variant="body2">
-                    {t('pxb:MESSAGES.ERROR')}: {t(transitErrorMessage)}
-                </Typography>
                 {loginErrorDisplayConfig.dismissible !== false && (
                     <CloseIcon
                         className={classes.errorBoxDismissIcon}
@@ -242,6 +242,7 @@ export const Login: React.FC = () => {
                         }}
                     />
                 )}
+                <Typography variant="body2">{t(transitErrorMessage)}</Typography>
             </div>
         ) : (
             <></>
@@ -395,6 +396,10 @@ export const Login: React.FC = () => {
                         helperText={isInvalidCredentials ? t('pxb:LOGIN.INCORRECT_CREDENTIALS') : ''}
                     />
 
+                    {(loginErrorDisplayConfig.mode === 'message-box' || loginErrorDisplayConfig.mode === 'both') &&
+                        loginErrorDisplayConfig.position === 'bottom' &&
+                        errorMessageBox}
+
                     <Grid
                         container
                         direction="row"
@@ -431,9 +436,6 @@ export const Login: React.FC = () => {
                         </Button>
                     </Grid>
 
-                    {(loginErrorDisplayConfig.mode === 'message-box' || loginErrorDisplayConfig.mode === 'both') &&
-                        loginErrorDisplayConfig.position === 'bottom' &&
-                        errorMessageBox}
                     {loginActions && typeof loginActions === 'function' && loginActions(null)}
                     {loginActions && typeof loginActions !== 'function' && loginActions}
 

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -147,7 +147,7 @@ export const Login: React.FC = () => {
     const authUIState = useAccountUIState();
     const { routes } = useRoutes();
     const theme = useTheme();
-    const { loginErrorDisplayConfig = { mode: 'dialog' } } = useInjectedUIContext();
+    const { loginErrorDisplayConfig = { mode: 'dialog' }, ...otherUIContext } = useInjectedUIContext();
     const classes = useStyles(loginErrorDisplayConfig);
     const {
         showRememberMe = true,
@@ -165,7 +165,7 @@ export const Login: React.FC = () => {
         ),
         loginType = 'email',
         loginActions,
-    } = useInjectedUIContext();
+    } = otherUIContext;
 
     const passwordField = useRef<any>(null);
 

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -334,7 +334,9 @@ export const Login: React.FC = () => {
 
     return (
         <BrandedCardContainer loading={transitState.transitInProgress}>
-            {(loginErrorDisplayConfig.mode === 'dialog' || loginErrorDisplayConfig.mode === 'both') && errorDialog}
+            {(loginErrorDisplayConfig.mode === 'dialog' || loginErrorDisplayConfig.mode === 'both') &&
+                transitErrorMessage &&
+                errorDialog}
             {debugButton}
             <form
                 onSubmit={(evt): void => {

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -334,7 +334,8 @@ export const Login: React.FC = () => {
 
     return (
         <BrandedCardContainer loading={transitState.transitInProgress}>
-            {(loginErrorDisplayConfig.mode === 'dialog' || loginErrorDisplayConfig.mode === 'both') &&
+            {!isInvalidCredentials &&
+                (loginErrorDisplayConfig.mode === 'dialog' || loginErrorDisplayConfig.mode === 'both') &&
                 transitErrorMessage &&
                 errorDialog}
             {debugButton}

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -232,7 +232,7 @@ export const Login: React.FC = () => {
     );
 
     const errorMessageBox: JSX.Element =
-        hasTransitError && transitErrorMessage && showErrorMessageBox ? (
+        !isInvalidCredentials && hasTransitError && transitErrorMessage && showErrorMessageBox ? (
             <div className={classes.errorMessageBox}>
                 {loginErrorDisplayConfig.dismissible !== false && (
                     <CloseIcon

--- a/login-workflow/yarn.lock
+++ b/login-workflow/yarn.lock
@@ -1305,10 +1305,10 @@
   resolved "https://registry.yarnpkg.com/@pxblue/prettier-config/-/prettier-config-1.0.3.tgz#285b9ba346f714d397ef4a59579443b95a77e63e"
   integrity sha512-x9SDup4pf5H54r/stZBXz7/XlMcIqnwHkEJ+9pyXVtGyQljI28lDGQCWQj6heipWAett50yx0RB3P2+MWZDhJA==
 
-"@pxblue/react-auth-shared@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@pxblue/react-auth-shared/-/react-auth-shared-3.4.0.tgz#cfa80ed761e22ec8109b166dd53d6e0e35c47b51"
-  integrity sha512-O9iCUW2NpxcAs9RJmlQwXdnvFIMzjN+OXhqbE0b+cleIJugHs4rV/8Zm1UneT8PyK6zsEeMwdI+SFG3F2j19UQ==
+"@pxblue/react-auth-shared@^3.5.0-beta.0":
+  version "3.5.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@pxblue/react-auth-shared/-/react-auth-shared-3.5.0-beta.0.tgz#ce0b0e93081ec574f99709bcfc9ec7719baaa930"
+  integrity sha512-C0g1Uoyu3kGiYR9wxeQFBtev/z1h/fsrMPnOY6vyd3AN7vvvAqNX5aquosRx9lIOqyPHq3vm944p0Lxz13vZXw==
 
 "@pxblue/react-components@^5.2.0":
   version "5.2.0"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes PXBLUE-2313.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add ability to customize how login error messages are displayed

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Checkout the `feature/standardize-login-error` branch for `react-auth-shared`
- Modify example `AuthUiActions.tsx` login method to immediately return an error (e.g., `throw new Error('LOGIN.INVALID_CREDENTIALS');`)
- Spin up workflow example project
- Add a loginErrorDisplayConfig to the example `App.tsx` (see examples below)
- Observe various error message configs

example configs
` loginErrorDisplayConfig={{ mode: 'dialog' }}`
`loginErrorDisplayConfig={{ mode: 'message-box', position: 'top' }}`
`loginErrorDisplayConfig={{ mode: 'message-box', position: 'bottom' }}`
`loginErrorDisplayConfig={{mode: 'message-box', position: 'top', backgroundColor: '#FFA1FF', fontColor: '#00CA00', dismissible: false }}`
`loginErrorDisplayConfig={{ mode: 'both' }}`
`loginErrorDisplayConfig={{ mode: 'none' }}`
