### PR TITLE
Fix error messages during change password

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.3.1 (August 12, 2021)
+
+### Fixed
+
+-   Issue with error messages not being displayed while changing password ([#77](https://github.com/pxblue/react-workflows/issues/77)).
+
 ## v2.3.0 (July 27, 2021)
 
 ### Fixed

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pxblue/react-auth-workflow",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "author": "Power Xpert Blue <pxblue@eaton.com> (https://github.com/pxblue)",
     "license": "BSD-3-Clause",
     "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",

--- a/login-workflow/src/components/password/ChangePasswordModal.tsx
+++ b/login-workflow/src/components/password/ChangePasswordModal.tsx
@@ -83,7 +83,7 @@ export const ChangePasswordModal: React.FC = () => {
             await accountUIActions.actions.changePassword(currentPassword, password);
             setTransitState(transitSuccess());
         } catch (error) {
-            setTransitState(transitFailed(error.errorMessage));
+            setTransitState(transitFailed(error.message));
         }
     }, [accountUIActions, currentPassword, password]);
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #77 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update the error message key from error.errorMessage to error.message

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/29152776/128914975-16f6a498-c813-4e18-a4fb-a0ddb3ed259f.png)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Clone down the demo
- Throw an error in the changePassword action
- Confirm that the error message is displayed in the dialog box when attempting to change the password
